### PR TITLE
Dependency automation: Renovate for versions, Dependabot for security, daily audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,69 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
+# Dependabot here is deliberately limited to SECURITY updates only.
+#
+# Renovate owns routine version updates (see renovate.json). Running both on
+# version updates would open two PRs for every bump, so every entry below sets
+# `open-pull-requests-limit: 0`, which suppresses Dependabot's scheduled version
+# PRs while still letting it raise a PR the moment an advisory affects a pinned
+# dependency. That is the one job Renovate cannot do as well: Dependabot is wired
+# straight into the GitHub Advisory Database and the repo's alerts.
+#
+# NOTE: this file alone is inert. "Dependabot alerts" and "Dependabot security
+# updates" must also be switched on in
+#   Settings -> Advanced Security (or Code security and analysis)
+# for the repository, otherwise nothing here fires.
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # Flask API service
+  - package-ecosystem: "pip"
+    directory: "/api"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    labels:
+      - "dependencies"
+      - "security"
+  # MCP server
+  - package-ecosystem: "pip"
+    directory: "/mcp-server"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    labels:
+      - "dependencies"
+      - "security"
+  # SharePoint term-store connector
+  - package-ecosystem: "pip"
+    directory: "/connectors/sharepoint-termstore"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    labels:
+      - "dependencies"
+      - "security"
+  # Fuseki base image (digest-pinned in deploy/Dockerfile)
+  - package-ecosystem: "docker"
+    directory: "/deploy"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    labels:
+      - "dependencies"
+      - "security"
+  # Workflow actions, pinned to commit SHAs
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    labels:
+      - "dependencies"
+      - "security"
+  # Audit tooling used by the security-audit workflow
+  - package-ecosystem: "pip"
+    directory: "/.github/scripts"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    labels:
+      - "dependencies"
+      - "security"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@
 # dependency. That is the one job Renovate cannot do as well: Dependabot is wired
 # straight into the GitHub Advisory Database and the repo's alerts.
 #
+# The interval below is "daily" to match the repository's stated preference, but note
+# it has little practical effect here: `open-pull-requests-limit: 0` suppresses the
+# scheduled version PRs the interval governs, and security PRs are raised when an
+# advisory lands, not on a schedule.
+#
 # NOTE: this file alone is inert. "Dependabot alerts" and "Dependabot security
 # updates" must also be switched on in
 #   Settings -> Advanced Security (or Code security and analysis)
@@ -17,7 +22,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/api"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 0
     labels:
       - "dependencies"
@@ -26,7 +31,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/mcp-server"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 0
     labels:
       - "dependencies"
@@ -35,7 +40,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/connectors/sharepoint-termstore"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 0
     labels:
       - "dependencies"
@@ -44,7 +49,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/deploy"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 0
     labels:
       - "dependencies"
@@ -53,7 +58,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 0
     labels:
       - "dependencies"
@@ -62,7 +67,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/.github/scripts"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 0
     labels:
       - "dependencies"

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -1,0 +1,3 @@
+# Tooling for the daily security-audit workflow. Pinned like everything else, so
+# the auditor itself is auditable and Renovate keeps it current.
+pip-audit==2.10.1

--- a/.github/scripts/security_audit.py
+++ b/.github/scripts/security_audit.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Daily dependency & supply-chain audit.
+
+Five checks, all of them things that go quietly wrong between releases:
+
+  1. known CVEs in the pinned Python dependencies         (pip-audit)
+  2. base-image digest drift  -- the pinned sha256 no longer being what the
+     upstream tag resolves to, i.e. the build is stuck on an unpatched base
+  3. Subresource Integrity drift -- an `integrity=` hash in an HTML file that no
+     longer matches the bytes npm publishes for that exact version
+  4. loosened Python pins -- a requirement that stopped being `==`
+  5. unpinned GitHub Actions -- a `uses:` on a mutable tag instead of a SHA
+
+Writes Markdown to --output and exits 0 unless --fail-on-findings is passed.
+The workflow reads `findings=true|false` from GITHUB_OUTPUT to decide whether to
+open, update, or close the tracking issue.
+
+Deliberately dependency-light: only pip-audit is external, everything else is
+stdlib, so the audit itself adds no supply-chain surface worth speaking of.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+import tarfile
+import urllib.request
+from pathlib import Path
+
+TIMEOUT = 60
+findings: list[tuple[str, str, str]] = []  # (severity, check, markdown detail)
+notes: list[str] = []
+
+
+def add(sev: str, check: str, detail: str) -> None:
+    findings.append((sev, check, detail))
+
+
+def get_json(url: str, headers: dict | None = None):
+    req = urllib.request.Request(url, headers=headers or {})
+    with urllib.request.urlopen(req, timeout=TIMEOUT) as r:
+        return json.load(r)
+
+
+# ---------------------------------------------------------------- 1. pip-audit
+def check_pip(root: Path) -> None:
+    reqs = sorted(p for p in root.rglob("requirements*.txt")
+                  if ".git" not in p.parts and "node_modules" not in p.parts)
+    if not reqs:
+        notes.append("No requirements files found.")
+        return
+    for req in reqs:
+        rel = req.relative_to(root)
+        try:
+            proc = subprocess.run(
+                [sys.executable, "-m", "pip_audit", "-r", str(req),
+                 "--format", "json", "--progress-spinner", "off"],
+                capture_output=True, text=True, timeout=900)
+        except subprocess.TimeoutExpired:
+            add("WARN", "pip-audit", f"`{rel}` — audit timed out.")
+            continue
+        raw = proc.stdout.strip()
+        if not raw:
+            add("WARN", "pip-audit",
+                f"`{rel}` — pip-audit produced no output.\n\n```\n{proc.stderr.strip()[-1500:]}\n```")
+            continue
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            add("WARN", "pip-audit", f"`{rel}` — could not parse pip-audit output.")
+            continue
+        hits = 0
+        for dep in data.get("dependencies", []):
+            for v in dep.get("vulns", []):
+                hits += 1
+                fix = ", ".join(v.get("fix_versions") or []) or "none published"
+                add("HIGH", "pip-audit",
+                    f"`{rel}` — **{dep['name']} {dep['version']}** is affected by "
+                    f"[{v['id']}](https://osv.dev/vulnerability/{v['id']}). "
+                    f"Fixed in: {fix}.")
+        if not hits:
+            notes.append(f"`{rel}` — no known vulnerabilities.")
+
+
+# --------------------------------------------------- 2. base-image digest drift
+def registry_token(repo: str) -> str:
+    return get_json("https://auth.docker.io/token?service=registry.docker.io"
+                    f"&scope=repository:{repo}:pull")["token"]
+
+
+def check_docker(root: Path) -> None:
+    accept = ",".join([
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.docker.distribution.manifest.v2+json"])
+    pat = re.compile(r"^FROM\s+(?P<image>[^\s@:]+):(?P<tag>[^\s@]+)@(?P<digest>sha256:[0-9a-f]{64})",
+                     re.MULTILINE)
+    for df in sorted(root.rglob("Dockerfile*")):
+        if ".git" in df.parts:
+            continue
+        rel = df.relative_to(root)
+        for m in pat.finditer(df.read_text(encoding="utf-8", errors="replace")):
+            image, tag, pinned = m["image"], m["tag"], m["digest"]
+            repo = image if "/" in image else f"library/{image}"
+            try:
+                tok = registry_token(repo)
+                req = urllib.request.Request(
+                    f"https://registry-1.docker.io/v2/{repo}/manifests/{tag}",
+                    headers={"Authorization": f"Bearer {tok}", "Accept": accept},
+                    method="HEAD")
+                with urllib.request.urlopen(req, timeout=TIMEOUT) as r:
+                    live = r.headers.get("Docker-Content-Digest")
+            except Exception as e:                      # network/registry problems
+                add("WARN", "base-image", f"`{rel}` — could not reach registry for `{image}:{tag}`: {e}")
+                continue
+            if not live:
+                add("WARN", "base-image", f"`{rel}` — registry returned no digest for `{image}:{tag}`.")
+            elif live != pinned:
+                add("HIGH", "base-image",
+                    f"`{rel}` — `{image}:{tag}` now resolves to `{live}` but the Dockerfile pins "
+                    f"`{pinned}`. The build is on a stale base image and is missing whatever "
+                    f"base-OS patches the rebuild carried. Update the digest.")
+            else:
+                notes.append(f"`{rel}` — `{image}:{tag}` digest is current.")
+
+
+# ------------------------------------------------------------- 3. SRI integrity
+SCRIPT_TAG = re.compile(r"<script\b[^>]*>", re.IGNORECASE)
+ATTR = {k: re.compile(rf'{k}\s*=\s*"([^"]+)"', re.IGNORECASE) for k in ("src", "integrity")}
+CDN = re.compile(r"https://(?:unpkg\.com|cdn\.jsdelivr\.net/npm)/"
+                 r"(?P<name>(?:@[^/@]+/)?[^/@]+)@(?P<ver>[^/]+)/(?P<path>[^\"?]+)")
+
+
+def npm_file_bytes(name: str, ver: str, path: str) -> bytes:
+    meta = get_json(f"https://registry.npmjs.org/{name}/{ver}")
+    dist = meta["dist"]
+    with urllib.request.urlopen(dist["tarball"], timeout=TIMEOUT) as r:
+        tgz = r.read()
+    integ = dist.get("integrity")
+    if integ:                                   # verify the tarball before trusting it
+        alg, b64 = integ.split("-", 1)
+        if base64.b64encode(hashlib.new(alg, tgz).digest()).decode() != b64:
+            raise ValueError("npm tarball failed its own integrity check")
+    with tarfile.open(fileobj=io.BytesIO(tgz)) as tf:
+        member = tf.extractfile("package/" + path.lstrip("/"))
+        if member is None:
+            raise KeyError(path)
+        return member.read()
+
+
+def check_sri(root: Path) -> None:
+    for html in sorted(root.rglob("*.html")):
+        if ".git" in html.parts or "node_modules" in html.parts:
+            continue
+        rel = html.relative_to(root)
+        text = html.read_text(encoding="utf-8", errors="replace")
+        for tag in SCRIPT_TAG.findall(text):
+            src_m = ATTR["src"].search(tag)
+            if not src_m:
+                continue
+            src = src_m.group(1)
+            cdn = CDN.search(src)
+            if not cdn:
+                continue
+            integ_m = ATTR["integrity"].search(tag)
+            if not integ_m:
+                add("HIGH", "sri",
+                    f"`{rel}` — `{src}` is loaded from a CDN with **no integrity attribute**. "
+                    f"A compromised CDN would execute arbitrary JavaScript on this page.")
+                continue
+            if not re.fullmatch(r"[0-9]+(\.[0-9]+)*", cdn["ver"]):
+                add("MEDIUM", "sri",
+                    f"`{rel}` — `{cdn['name']}` is pinned to the floating tag `{cdn['ver']}`. "
+                    f"The integrity hash will break the page as soon as the tag moves; pin an exact version.")
+                continue
+            try:
+                data = npm_file_bytes(cdn["name"], cdn["ver"], cdn["path"])
+            except Exception as e:
+                add("WARN", "sri", f"`{rel}` — could not verify `{cdn['name']}@{cdn['ver']}`: {e}")
+                continue
+            alg = integ_m.group(1).split("-", 1)[0]
+            if alg not in ("sha256", "sha384", "sha512"):
+                add("WARN", "sri", f"`{rel}` — unrecognised integrity algorithm `{alg}`.")
+                continue
+            want = f"{alg}-" + base64.b64encode(hashlib.new(alg, data).digest()).decode()
+            if want != integ_m.group(1):
+                add("HIGH", "sri",
+                    f"`{rel}` — integrity hash for **{cdn['name']}@{cdn['ver']}** does not match what "
+                    f"npm publishes.\n\n  - in the file: `{integ_m.group(1)}`\n  - from npm:    `{want}`\n\n"
+                    f"Either the pin was bumped without refreshing the hash (the page is now broken for "
+                    f"every visitor), or the published bytes changed. Resolve before deploying.")
+            else:
+                notes.append(f"`{rel}` — SRI for `{cdn['name']}@{cdn['ver']}` verified.")
+
+
+# ------------------------------------------------------- 4. loosened pip pins
+def check_pins(root: Path) -> None:
+    for req in sorted(root.rglob("requirements*.txt")):
+        if ".git" in req.parts:
+            continue
+        rel = req.relative_to(root)
+        for i, line in enumerate(req.read_text(encoding="utf-8").splitlines(), 1):
+            s = line.split("#", 1)[0].strip()
+            if not s or s.startswith("-"):
+                continue
+            if "==" not in s:
+                add("MEDIUM", "pinning",
+                    f"`{rel}:{i}` — `{s}` is not pinned with `==`. Renovate and Dependabot cannot "
+                    f"raise updates for an open range, so this dependency silently stops being tracked.")
+
+
+# --------------------------------------------------- 5. unpinned GitHub Actions
+def check_actions(root: Path) -> None:
+    wf = root / ".github" / "workflows"
+    if not wf.is_dir():
+        return
+    uses = re.compile(r"uses:\s*(?P<ref>[A-Za-z0-9._-]+/[A-Za-z0-9._/-]+@(?P<v>\S+))")
+    for f in sorted(list(wf.glob("*.yml")) + list(wf.glob("*.yaml"))):
+        rel = f.relative_to(root)
+        for i, line in enumerate(f.read_text(encoding="utf-8").splitlines(), 1):
+            m = uses.search(line)
+            if m and not re.fullmatch(r"[0-9a-f]{40}", m["v"]):
+                add("MEDIUM", "actions",
+                    f"`{rel}:{i}` — `{m['ref']}` is pinned to a mutable tag. Whoever controls that "
+                    f"action can repoint the tag at new code, which then runs with this workflow's token. "
+                    f"Pin the full commit SHA.")
+
+
+# ------------------------------------------------------------------- reporting
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--output", default="audit-report.md")
+    ap.add_argument("--fail-on-findings", action="store_true")
+    a = ap.parse_args()
+    root = Path(a.root).resolve()
+
+    for fn in (check_pip, check_docker, check_sri, check_pins, check_actions):
+        try:
+            fn(root)
+        except Exception as e:                       # one broken check must not hide the others
+            add("WARN", fn.__name__, f"check raised `{type(e).__name__}: {e}`")
+
+    order = {"HIGH": 0, "MEDIUM": 1, "WARN": 2}
+    findings.sort(key=lambda f: (order.get(f[0], 3), f[1]))
+
+    out = [f"## Dependency & supply-chain audit — {root.name}", ""]
+    if findings:
+        highs = sum(1 for f in findings if f[0] == "HIGH")
+        out.append(f"**{len(findings)} finding(s)** — {highs} high severity." if highs
+                   else f"**{len(findings)} finding(s)** — none high severity.")
+        out.append("")
+        for sev, check, detail in findings:
+            out.append(f"- **{sev}** · `{check}` — {detail}")
+    else:
+        out.append("No findings. Dependencies, base-image digests, SRI hashes, "
+                   "pins and action refs all check out.")
+    if notes:
+        out += ["", "<details><summary>Checks that passed</summary>", ""]
+        out += [f"- {n}" for n in notes]
+        out += ["", "</details>"]
+    out += ["", "---", "",
+            "_Generated by `.github/scripts/security_audit.py` "
+            "(daily `security-audit` workflow)._"]
+    report = "\n".join(out)
+
+    Path(a.output).write_text(report, encoding="utf-8")
+    print(report)
+
+    gho = os.environ.get("GITHUB_OUTPUT")
+    if gho:
+        with open(gho, "a", encoding="utf-8") as fh:
+            fh.write(f"findings={'true' if findings else 'false'}\n")
+            fh.write(f"count={len(findings)}\n")
+
+    return 1 if (findings and a.fail_on_findings) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,8 @@
 name: Deploy to GitHub Pages
+# Actions are pinned to full commit SHAs, not tags. A tag is mutable: whoever
+# controls the action repo can repoint v4 at new code, which then runs here with
+# this workflow's token. The trailing comment records the human-readable version;
+# Renovate keeps both in step (renovate.json, pinDigests).
 on:
   push:
     branches: [main]
@@ -17,10 +21,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: app
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -15,11 +15,17 @@ on:
     - cron: "17 6 * * *"
   workflow_dispatch:
   push:
-    # Exercise the audit whenever the audit itself changes, so a broken checker
-    # is caught immediately rather than at 06:17 the next morning.
+    # Two reasons to run on push. First, when the audit itself changes, so a broken
+    # checker surfaces immediately rather than at 06:17 the next morning. Second,
+    # when anything the audit actually inspects changes -- without that, a loosened
+    # pin or a hand-edited digest sits unreported until the next nightly run, which
+    # is precisely the drift this workflow exists to catch.
     paths:
       - ".github/workflows/security-audit.yml"
       - ".github/scripts/**"
+      - "**/requirements*.txt"
+      - "deploy/Dockerfile"
+      - "deploy/docker-compose.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,116 @@
+# Daily dependency and supply-chain audit.
+#
+# Renovate and Dependabot open PRs when a dependency *has* an update. This catches
+# the things neither of them watches: a base-image digest that has gone stale, an
+# SRI hash that no longer matches the bytes npm serves, a pin that was loosened
+# back to a range, an action that slipped back to a mutable tag.
+#
+# Findings are collected into ONE issue that is updated in place and closed
+# automatically when a run comes back clean, so this never becomes issue spam.
+name: Security audit
+
+on:
+  schedule:
+    # 06:17 UTC — deliberately off the hour, where every other cron piles up.
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+  push:
+    # Exercise the audit whenever the audit itself changes, so a broken checker
+    # is caught immediately rather than at 06:17 the next morning.
+    paths:
+      - ".github/workflows/security-audit.yml"
+      - ".github/scripts/**"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: security-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install audit tooling
+        run: pip install -r .github/scripts/requirements.txt
+
+      - name: Run audit
+        id: audit
+        run: python .github/scripts/security_audit.py --root . --output audit-report.md
+
+      - name: Run repository security tests
+        # No-op in repos that have none; where they exist (e.g. the SSRF guard on
+        # the bring-your-own LLM endpoint) a regression fails the audit outright.
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          tests=(tests/test_*.py)
+          if [ ${#tests[@]} -eq 0 ]; then
+            echo "No repository tests present."
+            exit 0
+          fi
+          # The tests import application modules, so the app's own dependencies
+          # have to be present. Installed only when there is something to run.
+          for req in requirements.txt api/requirements.txt; do
+            [ -f "$req" ] && pip install -r "$req"
+          done
+          for t in "${tests[@]}"; do
+            echo "--- $t"
+            python "$t"
+          done
+
+      - name: Upload report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: security-audit-report
+          path: audit-report.md
+          retention-days: 30
+
+      - name: Open or update the tracking issue
+        if: steps.audit.outputs.findings == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh label create security-audit --color B60205 \
+            --description "Raised by the daily security audit" 2>/dev/null || true
+          TITLE="Security audit: ${{ steps.audit.outputs.count }} open finding(s)"
+          {
+            echo "Run: [\`${GITHUB_RUN_ID}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) · commit \`${GITHUB_SHA:0:7}\`"
+            echo
+            cat audit-report.md
+          } > issue-body.md
+          NUM=$(gh issue list --label security-audit --state open \
+                  --json number --jq '.[0].number // empty')
+          if [ -n "$NUM" ]; then
+            gh issue edit  "$NUM" --title "$TITLE" --body-file issue-body.md
+            echo "Updated issue #$NUM"
+          else
+            gh issue create --title "$TITLE" --body-file issue-body.md \
+                            --label security-audit
+          fi
+
+      - name: Close the tracking issue when clean
+        if: steps.audit.outputs.findings == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          NUM=$(gh issue list --label security-audit --state open \
+                  --json number --jq '.[0].number // empty')
+          if [ -n "$NUM" ]; then
+            gh issue comment "$NUM" --body \
+              "Audit is clean as of commit \`${GITHUB_SHA:0:7}\`. Closing; it will reopen if anything regresses."
+            gh issue close "$NUM"
+            echo "Closed issue #$NUM"
+          else
+            echo "Clean, and no open audit issue. Nothing to do."
+          fi

--- a/SECURITY-AUDIT.md
+++ b/SECURITY-AUDIT.md
@@ -1,0 +1,132 @@
+# Security & supply-chain audit
+
+**Date:** 2026-08-30
+**Scope:** dependency management, supply-chain integrity, and a review of the
+security-relevant code paths in this repository.
+
+This file records what was checked, what was changed, and — as importantly — what
+was looked at and left alone, so the next audit starts from a known baseline
+rather than from scratch.
+
+## What now runs continuously
+
+| | Owner | Cadence |
+|---|---|---|
+| Version update PRs | **Renovate** (`renovate.json`) | Weekly, Monday before 06:00 UTC |
+| Security advisory PRs | **Dependabot** (`.github/dependabot.yml`) | Immediately on advisory |
+| Pin / digest / SRI drift | **`security-audit` workflow** | Daily, 06:17 UTC |
+
+The two bots are deliberately not doing the same job. Every Dependabot entry sets
+`open-pull-requests-limit: 0`, which suppresses its routine version PRs while leaving
+its advisory-driven PRs switched on. Without that split, both bots would open a PR
+for every bump.
+
+The daily workflow covers what neither bot watches: a base-image digest that has gone
+stale, a pin quietly loosened back to a range, an action that slipped back to a mutable
+tag, an SRI hash that no longer matches the published bytes. Findings collect into a
+single issue that is updated in place and closed automatically when a run comes back
+clean.
+
+## Finding: dependencies were not pinned (fixed)
+
+**Severity: high — it disabled dependency management entirely.**
+
+Every requirement was an open range (`flask>=3.0`, `rdflib>=7.0`). Neither Renovate nor
+Dependabot can raise a version PR against `>=3.0`, because every new release already
+satisfies it. The dependency tooling would have been installed and silently done nothing.
+
+All requirements are now pinned with `==`. The daily audit re-checks this, so a pin
+loosened back to a range is reported rather than quietly dropping that dependency out
+of tracking.
+
+## Finding: the Fuseki base image was pinned to a stale digest (fixed)
+
+**Severity: high.** `deploy/Dockerfile` pinned `eclipse-temurin:17-jre` by digest —
+correct practice — but the tag had since moved to a newly built image and the pin had
+not. Every build was reproducibly producing a container on a base image that no longer
+matched upstream, missing whatever base-OS patches that rebuild carried. A digest pin
+without a freshness check trades one risk for another.
+
+Refreshed to `sha256:13cc28a6…`, verified as a like-for-like OCI index covering the same
+six platforms. Renovate's Docker manager now raises this bump, and the daily audit fails
+if the pin drifts from the live tag again.
+
+## Finding: Apache Jena version tracked in two places that could diverge (fixed)
+
+`ARG FUSEKI_VERSION` in `deploy/Dockerfile` and the image tag in
+`deploy/docker-compose.yml` both name the Fuseki version, and nothing kept them in step.
+A Renovate custom manager now tracks both, so they move together. `FUSEKI_SHA512` still
+has to be re-verified by hand against the Apache release — Renovate cannot compute a
+tarball hash, and this is called out in the config so a bump PR is not merged blind.
+## Finding: workflow actions pinned to mutable tags (fixed)
+
+**Severity: medium.** `.github/workflows/pages.yml` used `actions/checkout@v4` and friends.
+A tag is mutable: whoever controls an action repository can repoint `v4` at new code, which
+then runs in this workflow with its token and `pages: write` / `id-token: write` permissions.
+
+All four actions are now pinned to full commit SHAs with the human-readable version in a
+trailing comment. The majors were *not* changed at the same time — newer majors exist
+(checkout v7, configure-pages v6, upload-pages-artifact v5, deploy-pages v5) and Renovate
+will propose them as reviewable PRs rather than having them bundled into a security fix.
+The workflow's `permissions` block was already correctly scoped and was left alone.
+
+## Finding: no CSP or transport-security headers (fixed)
+
+`netlify.toml` set `X-Content-Type-Options` and `Referrer-Policy` but no Content-Security-Policy,
+HSTS, or frame protection. Added: CSP, `Strict-Transport-Security`, `X-Frame-Options: DENY`,
+and a `Permissions-Policy` turning off device APIs the editor never uses.
+
+A matching CSP also went into `app/index.html` as a `<meta http-equiv>`, so the policy travels
+with the file to GitHub Pages, which cannot set response headers at all.
+
+Two deliberate loosenings, both documented in the config:
+
+- `script-src` includes `'unsafe-inline'` — the app is one self-contained HTML file, so its
+  own logic is inline. It still blocks *external* scripts, which is the injection vector that
+  matters. `'unsafe-eval'` is **not** granted: the app contains no `eval` or `new Function`.
+- `connect-src` is open — the SPARQL endpoint is typed in by the user at runtime and can be
+  any host, so narrowing it would break the Fuseki sync feature outright.
+
+Verified in Chromium: the app renders fully (20 top-level elements, 124 controls) with zero
+CSP violations and zero page errors.
+
+## Open — reported, not fixed
+
+- **`innerHTML` is used in ~139 places** in `app/index.html`, some of them rendering values
+  that originate in imported RDF/CSV. That is a DOM-XSS surface: a malicious label in an
+  imported vocabulary could inject markup. The CSP blocks external script loads, which
+  substantially limits what an injection can reach, but `'unsafe-inline'` means it does not
+  stop inline execution. Converting these to `textContent`/`insertAdjacentText` where the
+  value is untrusted is the real fix, and it is a focused refactor rather than part of a
+  dependency change — worth its own piece of work.
+## Reviewed and found sound — no change made
+
+- **The Dockerfile.** Base image pinned by digest, Fuseki tarball verified by SHA-512
+  before extraction, build tooling purged afterwards, and the server runs as a non-root
+  user (uid 1001). This was already stronger than most; the only gap was digest freshness,
+  above.
+- **`docker-compose.yml`.** Bound to `127.0.0.1` only, no admin password baked in, and the
+  image is built locally rather than pulled — so there is no third-party image to trust.
+- **Credentials.** No secrets committed; a scan for key-shaped literals and for
+  `.env`/`.pem`/`.key` files found nothing.
+
+## Two steps that need a human
+
+Neither can be done from a commit:
+
+1. **Install the Renovate GitHub App** — <https://github.com/apps/renovate> — and grant it
+   this repository. `renovate.json` does nothing until an app is watching the repo.
+2. **Enable Dependabot alerts and security updates** in
+   *Settings → Advanced Security* (or *Code security and analysis*). `dependabot.yml`
+   configures Dependabot; it does not switch it on.
+
+The daily `security-audit` workflow needs neither, and starts working on the first push.
+
+## Method
+
+`pip-audit` against every resolved dependency set; a Renovate dry run
+(`renovate --platform=local`) to confirm every manager matches real files; live registry
+queries for base-image digest freshness; and a read of the security-relevant code paths.
+Configuration was validated with `renovate-config-validator --strict` and by parsing every
+YAML file. The Content-Security-Policy was verified by loading the app in Chromium and
+confirming it renders with zero CSP violations and zero page errors.

--- a/SECURITY-AUDIT.md
+++ b/SECURITY-AUDIT.md
@@ -27,17 +27,32 @@ tag, an SRI hash that no longer matches the published bytes. Findings collect in
 single issue that is updated in place and closed automatically when a run comes back
 clean.
 
-## Finding: dependencies were not pinned (fixed)
+## Change: dependencies are now pinned exactly
 
-**Severity: high — it disabled dependency management entirely.**
+**Severity: medium — a gap in coverage and reproducibility, not a vulnerability.**
 
-Every requirement was an open range (`flask>=3.0`, `rdflib>=7.0`). Neither Renovate nor
-Dependabot can raise a version PR against `>=3.0`, because every new release already
-satisfies it. The dependency tooling would have been installed and silently done nothing.
+Every requirement was an open range (`flask>=3.0`, `rdflib>=7.0`). What the two tools do
+with that differs, and the distinction matters:
+
+- **Dependabot does raise PRs against an open range**, widening the lower bound — this
+  repository's own history shows it, in closed PRs titled
+  "Update flask requirement from >=3.0 to >=3.1.3".
+- **Renovate, on its default range strategy, leaves a satisfied range alone.** Nothing to
+  replace when `7.6.0` already satisfies `>=7.0`, so those dependencies would have sat
+  outside Renovate's coverage entirely.
+
+So pinning is not what makes dependency management work — it is what makes both tools
+see the same thing, and what makes a build reproducible: an unpinned range means the
+version you deployed is whatever PyPI served that day, and is not recorded anywhere.
+
+An earlier draft of this document claimed neither tool could act on `>=3.0`. That was
+wrong about Dependabot, and is corrected here. The commit messages on this branch still
+carry the original overstatement; rewriting them would mean rewriting published history,
+so the correction lives here instead.
 
 All requirements are now pinned with `==`. The daily audit re-checks this, so a pin
 loosened back to a range is reported rather than quietly dropping that dependency out
-of tracking.
+of Renovate's tracking.
 
 ## Finding: the Fuseki base image was pinned to a stale digest (fixed)
 
@@ -50,6 +65,16 @@ without a freshness check trades one risk for another.
 Refreshed to `sha256:13cc28a6…`, verified as a like-for-like OCI index covering the same
 six platforms. Renovate's Docker manager now raises this bump, and the daily audit fails
 if the pin drifts from the live tag again.
+
+### Why the tag stays `17-jre`
+
+Renovate will offer to retag the base image to a point release (`17.0.20_8-jre`) or to
+Java 25 (`25.0.4_7-jre`). Both are declined by an `allowedVersions` rule in
+`renovate.json`, and deliberately so: a point-release tag stops moving, and the daily
+audit's whole base-image check is "does the pinned digest still match what this tag
+resolves to". Freeze the tag and that check quietly becomes a no-op — which is exactly
+how the stale digest above went unnoticed in the first place. The tag stays floating;
+the digest is pinned and Renovate keeps it fresh.
 
 ## Finding: Apache Jena version tracked in two places that could diverge (fixed)
 
@@ -119,6 +144,9 @@ Neither can be done from a commit:
 2. **Enable Dependabot alerts and security updates** in
    *Settings → Advanced Security* (or *Code security and analysis*). `dependabot.yml`
    configures Dependabot; it does not switch it on.
+   **This one appears already done for this repository** — Dependabot has previously
+   opened PRs here (#6–#15, since closed against a rewritten base), which it could not
+   have done while switched off. Worth confirming rather than assuming.
 
 The daily `security-audit` workflow needs neither, and starts working on the first push.
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,3 +1,5 @@
-flask>=3.0
-rdflib>=7.0
-pyshacl>=0.26
+# Pinned exactly so builds are reproducible and Renovate/Dependabot can see and
+# raise updates. Renovate keeps these current; do not loosen to ranges.
+Flask==3.1.3
+rdflib==7.6.0
+pyshacl==0.40.1

--- a/app/index.html
+++ b/app/index.html
@@ -9,6 +9,14 @@
   Taxonomies you create with this tool are your own; this license covers the editor.
 -->
 <meta charset="utf-8">
+<!-- Content Security Policy, carried in the document so it applies wherever this
+     file is served from — GitHub Pages and a plain file:// open included, neither of
+     which can set response headers. The Netlify deploy additionally sends this as a
+     real header, along with HSTS and frame-ancestors, which a meta tag cannot express.
+     script-src omits 'unsafe-eval' on purpose (the app uses no eval/new Function);
+     connect-src stays open because the SPARQL endpoint is supplied by the user at
+     runtime and can be any host. -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src *; object-src 'none'; base-uri 'none'; form-action 'self'">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Intentional Arrangement SKOS</title>
 </head>

--- a/connectors/sharepoint-termstore/requirements.txt
+++ b/connectors/sharepoint-termstore/requirements.txt
@@ -1,9 +1,12 @@
+# Pinned exactly so builds are reproducible and Renovate/Dependabot can see and
+# raise updates. Renovate keeps these current; do not loosen to ranges.
+
 # Mapping engine (offline conversion) needs only:
-rdflib>=7.0
+rdflib==7.6.0
 
 # Live pull from Microsoft Graph adds:
-msal>=1.28
-requests>=2.31
+msal==1.38.0
+requests==2.34.2
 
 # Bridge service (live sync) adds:
-flask>=3.0
+Flask==3.1.3

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -5,7 +5,12 @@
 # reproducible and auditable:
 #   * base image  -> pinned by digest
 #   * Fuseki tar  -> verified by SHA-512
-FROM eclipse-temurin:17-jre@sha256:cbc584b3776ab71410502680e6e85b5f1cd18c92c7bd680c10bc2a40bf678558
+#
+# The base digest must be refreshed as the upstream 17-jre tag moves, or the build
+# keeps rebuilding on an image that no longer has the current base-OS patches.
+# Renovate's dockerfile manager raises that bump automatically (renovate.json), and
+# the daily security-audit workflow fails if the pin drifts from the live tag.
+FROM eclipse-temurin:17-jre@sha256:13cc28a6cc72a38ce1f00c906be3580c1a3e604b8984d694f369a96742abc93b
 
 ARG FUSEKI_VERSION=5.6.0
 ARG FUSEKI_SHA512=53dfe13cdd5f6387a0c62917e275fde2cd2e2f2052bfe7515384934f24915228b8512a2dd2b50b7060cc300c976254349d991fcea239484cae48e0a59d67cd54

--- a/mcp-server/requirements.txt
+++ b/mcp-server/requirements.txt
@@ -1,3 +1,5 @@
-mcp>=2.0
-rdflib>=7.0
-pyshacl>=0.26
+# Pinned exactly so builds are reproducible and Renovate/Dependabot can see and
+# raise updates. Renovate keeps these current; do not loosen to ranges.
+mcp==2.1.1
+rdflib==7.6.0
+pyshacl==0.40.1

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,3 +10,33 @@
     Cache-Control = "no-cache"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "no-referrer"
+
+    # Clickjacking: nothing should ever frame the editor.
+    X-Frame-Options = "DENY"
+
+    # Force HTTPS for a year, including subdomains. Netlify terminates TLS, so
+    # this is safe to send unconditionally.
+    Strict-Transport-Security = "max-age=31536000; includeSubDomains"
+
+    # Drop access to device APIs the editor has no use for.
+    Permissions-Policy = "geolocation=(), microphone=(), camera=(), payment=(), usb=(), interest-cohort=()"
+
+    # Content Security Policy. Notes on why it is shaped this way:
+    #
+    #  script-src 'self' 'unsafe-inline'
+    #      The app is one self-contained HTML file, so its own logic is inline and
+    #      'unsafe-inline' is unavoidable without a build step. It still blocks the
+    #      thing that matters most here — pulling in an EXTERNAL script — so a
+    #      compromised CDN or an injected <script src> cannot execute.
+    #      There is no eval() or new Function() in the app, so 'unsafe-eval' is
+    #      deliberately NOT granted.
+    #
+    #  connect-src *
+    #      The SPARQL/Fuseki endpoint is typed in by the user at runtime and can be
+    #      any host (localhost:3030, an intranet box, a hosted triplestore), so this
+    #      cannot be narrowed without breaking the core sync feature. Restricting it
+    #      would need an allowlist the user maintains.
+    #
+    #  object-src/base-uri 'none'
+    #      Kill plugin embedding and <base> injection outright; the app uses neither.
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src *; object-src 'none'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'"

--- a/renovate.json
+++ b/renovate.json
@@ -82,6 +82,16 @@
       "groupName": "container base images"
     },
     {
+      "description": "Hold the base image on the floating 17-jre tag and let only the digest move. Renovate otherwise proposes retagging to a point release (17.0.20_8-jre) or to Java 25 (25.0.4_7-jre). A point-release tag stops moving, which would make the daily digest-drift check meaningless -- and that check is what catches an unpatched base image. allowedVersions filters candidate TAGS during lookup; digest updates are a separate mechanism and keep working.",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchDepNames": [
+        "eclipse-temurin"
+      ],
+      "allowedVersions": "/^17-jre$/"
+    },
+    {
       "description": "Fuseki majors change the server config surface; never automate them.",
       "matchDepNames": [
         "org.apache.jena:jena-fuseki-main"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "description": "Renovate owns version updates here. Dependabot is configured for security updates only (.github/dependabot.yml), so the two never open duplicate PRs.",
+  "timezone": "Etc/UTC",
+  "schedule": [
+    "before 6am on monday"
+  ],
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Renovate: dependency dashboard",
+  "prConcurrentLimit": 3,
+  "labels": [
+    "dependencies"
+  ],
+  "semanticCommits": "disabled",
+  "vulnerabilityAlerts": {
+    "description": "Security fixes ignore the weekly window and go out immediately.",
+    "schedule": [
+      "at any time"
+    ],
+    "labels": [
+      "dependencies",
+      "security"
+    ]
+  },
+  "lockFileMaintenance": {
+    "enabled": false
+  },
+  "customManagers": [
+    {
+      "description": "Apache Jena Fuseki version, tracked in two places that must move together: ARG FUSEKI_VERSION in deploy/Dockerfile and the local image tag in deploy/docker-compose.yml. Renovate raises the version; the SHA-512 in FUSEKI_SHA512 must be re-verified by hand against the Apache release before merging \u2014 Renovate cannot compute it.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^deploy/Dockerfile$/",
+        "/^deploy/docker-compose\\.yml$/"
+      ],
+      "matchStrings": [
+        "ARG FUSEKI_VERSION=(?<currentValue>[0-9.]+)",
+        "image:\\s*[a-z0-9-]+-fuseki:(?<currentValue>[0-9.]+)"
+      ],
+      "depNameTemplate": "org.apache.jena:jena-fuseki-main",
+      "datasourceTemplate": "maven"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Batch routine Python patch/minor bumps into one reviewable PR per repo.",
+      "matchManagers": [
+        "pip_requirements"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "python dependencies (patch/minor)"
+    },
+    {
+      "description": "Major Python bumps land alone \u2014 they need a human read of the changelog.",
+      "matchManagers": [
+        "pip_requirements"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": null
+    },
+    {
+      "description": "Pin GitHub Actions to full commit SHAs; a mutable tag is a supply-chain hole.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "pinDigests": true,
+      "groupName": "github actions"
+    },
+    {
+      "description": "Base image is pinned by digest on purpose \u2014 keep the digest fresh so base-OS CVEs get picked up.",
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "groupName": "container base images"
+    },
+    {
+      "description": "Fuseki majors change the server config surface; never automate them.",
+      "matchDepNames": [
+        "org.apache.jena:jena-fuseki-main"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "dependencyDashboardApproval": true
+    }
+  ]
+}


### PR DESCRIPTION
## What & why

Sets up dependency automation and fixes what the first audit found.

**Renovate owns version updates; Dependabot is limited to security updates.** Every Dependabot entry sets `open-pull-requests-limit: 0`, which suppresses its scheduled version PRs while leaving advisory-driven PRs on. Without that split, both bots open a PR for every bump.

This replaces the `.github/dependabot.yml` currently on main, which is GitHub's unedited starter template with `package-ecosystem: ""` — an invalid value, so Dependabot errors on the file and runs nothing. The interval here is `daily`, matching the intent of that commit, though with limit 0 it changes little: security PRs fire when an advisory lands, not on a schedule.

Dependencies are pinned exactly. Renovate on its default range strategy won't touch a satisfied `>=` range, so unpinned requirements sit outside its coverage; pinning also means the deployed version is recorded rather than being whatever PyPI served that day. (Dependabot *does* widen a `>=` lower bound — see #11 — so this is about coverage and reproducibility, not about making updates possible at all.)

### Issues found and fixed

- **Stale base-image digest.** `eclipse-temurin:17-jre` had moved to a rebuilt image while the Dockerfile still pinned the old digest, so builds were reproducibly missing whatever base-OS patches that rebuild carried. Refreshed, and confirmed a like-for-like OCI index over the same six platforms.
- **Mutable action tags.** `pages.yml` used `@v4`-style tags; whoever controls an action repo can repoint a tag at new code that then runs with this workflow's token. Now pinned to full commit SHAs with the version in a trailing comment. Majors were deliberately *not* bumped in the same change — see below.
- **No CSP or transport-security headers.** Added to `netlify.toml`, plus a matching `<meta http-equiv>` in `app/index.html` so the policy also applies on GitHub Pages, which can't set response headers.

### A daily audit for what neither bot watches

`.github/workflows/security-audit.yml` (06:17 UTC) runs `.github/scripts/security_audit.py`: CVEs in the pinned deps, base-image digest drift against the live tag, SRI hashes re-derived from npm, pins loosened off `==`, and actions back on mutable tags. Findings collect into one issue that's updated in place and closed automatically when a run comes back clean.

The base image stays on the floating `17-jre` tag by an `allowedVersions` rule. Renovate wanted to retag to `17.0.20_8-jre` or Java 25; a point-release tag stops moving, which would make the digest-drift check a no-op — which is how the stale digest went unnoticed in the first place.

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Docs
- [x] Refactor / cleanup

<sub>Closest fit — this is CI/dependency infrastructure plus a security fix, which the list doesn't cover directly.</sub>

## Checked

- [x] Opened `app/index.html` in a browser and ran through the affected tab — via `tools/smoke.py` against headless Chromium: **SMOKE PASS, 18 form groups, engine round-trip ok, console clean**, so the new CSP doesn't break the `core.js` / `vocab-data.js` split. Also confirmed the test *would* catch a CSP problem: tightening `script-src` to `'none'` fails it with 5 findings.
- [x] Export still validates — covered by the smoke test's export/import round trip.
- [x] Updated the relevant doc in `docs/` if behavior changed — behaviour is unchanged; the review is written up in `SECURITY-AUDIT.md`.
- [x] Change stays standards-aligned — no vocabulary or model changes.

Also: `renovate-config-validator --strict` passes, a `renovate --platform=local` dry run confirms every manager matches real files (26 deps across 7 files), and `security_audit.py` is clean on the rebased head.

## Notes for the reviewer

**Two steps I can't do from a commit:**

1. **Install the Renovate GitHub App** — <https://github.com/apps/renovate>. `renovate.json` does nothing until an app is watching the repo.
2. **Confirm Dependabot alerts are on.** This looks already done here — Dependabot has opened PRs in this repo before (#6–#15, since closed against a rewritten base) — but worth confirming rather than assuming.

**Correction carried in this branch.** An earlier draft of `SECURITY-AUDIT.md` claimed neither tool could raise a PR against `>=3.0`. That's wrong about Dependabot, and #11 in this repo is the counter-example. The document is corrected; the earlier commit messages still carry the overstatement, since fixing those would mean rewriting published history.

**Left for a separate change:** the GitHub Actions major bumps (checkout v4→v7, configure-pages v5→v6, upload-pages-artifact v3→v5, deploy-pages v4→v5). CI warns the current pins target Node 20, which GitHub is deprecating and already force-running on Node 24 — so these are worth taking, just not bundled into a security fix. The `innerHTML` DOM-XSS surface in `app/index.html` is also recorded in `SECURITY-AUDIT.md` and left alone; it's a focused refactor, not part of a dependency change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3HJpWPBrEUeke7K8BM4h2)_