### PR TITLE
Harden client against CodeQL XSS / XML-bomb findings

### DIFF
--- a/app/core.js
+++ b/app/core.js
@@ -1236,6 +1236,10 @@ function parseTurtle(text){ const { triples, prefixes } = parseTriples(text); re
 function parseRdfXml(text){
   const RDF = NS.rdf, XMLNS = "http://www.w3.org/XML/1998/namespace";
   const triples = [], prefixes = {};
+  // Entity-expansion guard (code-scanning: js/xml-bomb). RDF/XML has no need for a
+  // DOCTYPE, and that is the only place XML entities can be declared — reject it up
+  // front so a "billion laughs" payload can never reach the parser.
+  if (/<!DOCTYPE/i.test(text)) throw new Error("RDF/XML with a DOCTYPE declaration is not supported.");
   const doc = new DOMParser().parseFromString(text.replace(/^[\s﻿]+/, ""), "application/xml");
   const err = doc.getElementsByTagName("parsererror");
   if (err && err.length) throw new Error("RDF/XML parse error: " + (err[0].textContent || "").replace(/\s+/g, " ").trim().slice(0, 160));

--- a/app/index.html
+++ b/app/index.html
@@ -2480,7 +2480,7 @@ function renderCorpTable(){
     if($('#corpResMeta')) $('#corpResMeta').textContent = $('#corpResMeta').textContent.replace(/\d+ checked/, corpChecked.size+" checked");
   });
 }
-function escHtml(s){ return String(s).replace(/[&<>]/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;"}[c])); }
+function escHtml(s){ return String(s).replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c])); }
 function escAttr(s){ return String(s).replace(/[&<>"]/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;"}[c])); }
 
 function renderCorpDocs(){
@@ -2876,7 +2876,7 @@ if($('#xwTarget')){
     const cur=sc.value;
     sc.innerHTML=[
       `<option value="map" ${!pair?"disabled":""}>Mappings only — ${pair?n+" links":"pick a pair"}</option>`,
-      `<option value="pair" ${!pair?"disabled":""}>This pair as one thesaurus — ${pair?(A+" + "+B):"pick a pair"}</option>`,
+      `<option value="pair" ${!pair?"disabled":""}>This pair as one thesaurus — ${pair?(escapeHtml(A)+" + "+escapeHtml(B)):"pick a pair"}</option>`,
       `<option value="fed">Whole federation — ${fed.length} taxonomies</option>`].join("");
     sc.value=cur&&[...sc.options].some(o=>o.value===cur&&!o.disabled)?cur:(pair?"pair":"fed");
     const xl=$('#xwXl'); if(xl&&!xl.dataset.touched) xl.checked=!!((xwSourceModel&&xwSourceModel.xlLabels)||(xwTargetModel&&xwTargetModel.xlLabels));
@@ -5394,7 +5394,7 @@ function buildNavContents(){
   const curEl=document.querySelector('#tabs .tab.active'); const cur=curEl?curEl.getAttribute('data-tab'):'';
   const tabs=[...document.querySelectorAll('#tabs .tab')].map(t=>{ const c=t.cloneNode(true); c.querySelectorAll('.pill').forEach(p=>p.remove()); return {name:t.getAttribute('data-tab'), label:c.textContent.trim()}; });
   let h='<div class="nav-sec"><div class="nav-h">Go to</div>';
-  tabs.forEach(t=>{ h+=`<button class="nav-item${t.name===cur?' cur':''}" data-go="${t.name}">${escHtml(t.label)}</button>`; });
+  tabs.forEach(t=>{ h+=`<button class="nav-item${t.name===cur?' cur':''}" data-go="${escapeHtml(t.name)}">${escapeHtml(t.label)}</button>`; });
   h+='</div><div class="nav-sec"><div class="nav-h">Your data</div>'+
      '<button class="nav-item" data-act="backup">Download workspace backup</button>'+
      '<button class="nav-item" data-act="restore">Restore a backup…</button>'+


### PR DESCRIPTION
## Summary
Resolves the CodeQL code-scanning findings surfaced when default setup was re-enabled.

- **js/xml-bomb** — `parseRdfXml` now rejects a `DOCTYPE` declaration before `DOMParser` runs (RDF/XML never needs one; it's the only place XML entities are declared), closing the entity-expansion vector.
- **js/xss-through-dom** — HTML-escape project names in the crosswalk export `<option>` innerHTML; escape the slide-nav tab label + `data-go` via the canonical `escapeHtml`; and upgrade `escHtml` to a complete sanitizer (now escapes quotes too), covering every place it renders imported labels.

The 3 `py/stack-trace-exposure` findings were already fixed and confirmed **Fixed** by CodeQL in the prior merge.

## Verification
- DOCTYPE bomb payload rejected before parsing.
- Full headless-Chrome audit: **31/31 checks, console clean**, both apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
